### PR TITLE
added binder config and badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Mixed graduate and upper-level undergraduate course:
 * Students report ~6-12 hours outside of lab required to complete reading and homework
 
 ## Reproducing the GDA Course environment
-[Insert Binder badge]  
-Clicking this button will launch the GDA image on AWS us-west-2 using a pangeo binder. This will provide the same environment that was available on the course Jupyterhub during winter 2020. However, the session is ephemeral and your home directory will not persist, so use this only for running tutorials and other short-lived demos!
+[![badge](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/UW-GDA/gda_w2020/master?urlpath=git-pull?repo=https://github.com/UW-GDA/gda_w2020%26amp%3Bbranch=master%26amp%3Burlpath=lab)
+Clicking this button will launch the GDA image on [mybinder.org](https://mybinder.org). This will provide the same environment that was available on the course Jupyterhub during winter 2020. However, the session is ephemeral and your home directory will not persist, so use this only for running tutorials and other short-lived demos!
 
 ### Reproducing locally
 See the [Week 10 materials](./modules/10_Conda_Pangeo_Dask).

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,0 +1,5 @@
+FROM uwgda/uwgda-image:7bf885d
+# Note all image builds specified here:
+# https://github.com/UW-GDA/uwgda-image
+# And published here::
+# https://hub.docker.com/r/uwgda/uwgda-image/tags


### PR DESCRIPTION
added binder config that will launch the most recent image build (https://github.com/UW-GDA/uwgda-image/commit/7bf885d828343f9d60ec51ddbff9c05ea2dabb9d). Can modify to other builds if necessary. 

Also adds a binder badge link for mybinder.org, but it won't work until this repo is made public. 